### PR TITLE
fix(#2,#3,#4,#5): security fixes + error handling

### DIFF
--- a/src/app/(admin)/error.tsx
+++ b/src/app/(admin)/error.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+
+export default function AdminError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-start gap-4">
+      <h2 className="text-lg font-semibold">Что-то пошло не так</h2>
+      <p className="text-sm text-muted-foreground">{error.message}</p>
+      <Button variant="outline" onClick={reset}>
+        Попробовать снова
+      </Button>
+    </div>
+  );
+}

--- a/src/app/(admin)/not-found.tsx
+++ b/src/app/(admin)/not-found.tsx
@@ -1,0 +1,15 @@
+import Link from "next/link";
+
+export default function AdminNotFound() {
+  return (
+    <div className="flex flex-col items-start gap-4">
+      <h2 className="text-lg font-semibold">Страница не найдена</h2>
+      <p className="text-sm text-muted-foreground">
+        Запрошенный ресурс не существует или был удалён.
+      </p>
+      <Link href="/dashboard" className="text-sm text-primary hover:underline">
+        На главную
+      </Link>
+    </div>
+  );
+}

--- a/src/app/(admin)/venue-applications/[id]/page.tsx
+++ b/src/app/(admin)/venue-applications/[id]/page.tsx
@@ -37,18 +37,27 @@ export default async function VenueApplicationPage({ params }: { params: Promise
         <div className="mb-6">
           <h2 className="text-sm font-medium mb-2">Документы ({app.documentUrls.length})</h2>
           <ul className="space-y-1">
-            {app.documentUrls.map((url, i) => (
-              <li key={i}>
-                <a
-                  href={url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-sm text-primary hover:underline break-all"
-                >
-                  {url.split("/").pop() ?? `Документ ${i + 1}`}
-                </a>
-              </li>
-            ))}
+            {app.documentUrls.map((url, i) => {
+              const safe = isSafeUrl(url);
+              return (
+                <li key={i}>
+                  {safe ? (
+                    <a
+                      href={url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-sm text-primary hover:underline break-all"
+                    >
+                      {url.split("/").pop() ?? `Документ ${i + 1}`}
+                    </a>
+                  ) : (
+                    <span className="text-sm text-muted-foreground break-all" title="Небезопасный URL">
+                      {url.split("/").pop() ?? `Документ ${i + 1}`}
+                    </span>
+                  )}
+                </li>
+              );
+            })}
           </ul>
         </div>
       )}
@@ -56,6 +65,15 @@ export default async function VenueApplicationPage({ params }: { params: Promise
       {app.status === "PENDING" && <VenueApplicationActions id={app.id} />}
     </div>
   );
+}
+
+function isSafeUrl(url: string): boolean {
+  try {
+    const { protocol } = new URL(url);
+    return protocol === "https:" || protocol === "http:";
+  } catch {
+    return false;
+  }
 }
 
 function Row({ label, value, mono }: { label: string; value: React.ReactNode; mono?: boolean }) {

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -13,7 +13,7 @@ export async function POST(req: NextRequest) {
   const cookieOpts = {
     httpOnly: true,
     secure: SECURE,
-    sameSite: "lax" as const,
+    sameSite: "strict" as const,
     maxAge: MAX_AGE,
     path: "/",
   };

--- a/src/app/api/events/[id]/close-sales/route.ts
+++ b/src/app/api/events/[id]/close-sales/route.ts
@@ -12,6 +12,7 @@ export async function POST(_req: NextRequest, { params }: { params: Promise<{ id
     return NextResponse.json(result);
   } catch (e) {
     const msg = e instanceof Error ? e.message : "error";
-    return NextResponse.json({ error: msg }, { status: 500 });
+    const status = e instanceof Error && "status" in e ? (e as { status: number }).status : 500;
+    return NextResponse.json({ error: msg }, { status });
   }
 }

--- a/src/app/api/operations/close-started-event-sales/route.ts
+++ b/src/app/api/operations/close-started-event-sales/route.ts
@@ -9,6 +9,7 @@ export async function POST() {
     return NextResponse.json(result);
   } catch (e) {
     const msg = e instanceof Error ? e.message : "error";
-    return NextResponse.json({ error: msg }, { status: 500 });
+    const status = e instanceof Error && "status" in e ? (e as { status: number }).status : 500;
+    return NextResponse.json({ error: msg }, { status });
   }
 }

--- a/src/app/api/operations/process-stale-payments/route.ts
+++ b/src/app/api/operations/process-stale-payments/route.ts
@@ -9,6 +9,7 @@ export async function POST() {
     return NextResponse.json(result);
   } catch (e) {
     const msg = e instanceof Error ? e.message : "error";
-    return NextResponse.json({ error: msg }, { status: 500 });
+    const status = e instanceof Error && "status" in e ? (e as { status: number }).status : 500;
+    return NextResponse.json({ error: msg }, { status });
   }
 }

--- a/src/app/api/org-applications/[id]/approve/route.ts
+++ b/src/app/api/org-applications/[id]/approve/route.ts
@@ -12,6 +12,7 @@ export async function POST(_req: NextRequest, { params }: { params: Promise<{ id
     return NextResponse.json(result);
   } catch (e) {
     const msg = e instanceof Error ? e.message : "error";
-    return NextResponse.json({ error: msg }, { status: 500 });
+    const status = e instanceof Error && "status" in e ? (e as { status: number }).status : 500;
+    return NextResponse.json({ error: msg }, { status });
   }
 }

--- a/src/app/api/org-applications/[id]/reject/route.ts
+++ b/src/app/api/org-applications/[id]/reject/route.ts
@@ -12,6 +12,7 @@ export async function POST(_req: NextRequest, { params }: { params: Promise<{ id
     return NextResponse.json(result);
   } catch (e) {
     const msg = e instanceof Error ? e.message : "error";
-    return NextResponse.json({ error: msg }, { status: 500 });
+    const status = e instanceof Error && "status" in e ? (e as { status: number }).status : 500;
+    return NextResponse.json({ error: msg }, { status });
   }
 }

--- a/src/app/api/venue-applications/[id]/approve/route.ts
+++ b/src/app/api/venue-applications/[id]/approve/route.ts
@@ -12,6 +12,7 @@ export async function POST(_req: NextRequest, { params }: { params: Promise<{ id
     return NextResponse.json(result);
   } catch (e) {
     const msg = e instanceof Error ? e.message : "error";
-    return NextResponse.json({ error: msg }, { status: 500 });
+    const status = e instanceof Error && "status" in e ? (e as { status: number }).status : 500;
+    return NextResponse.json({ error: msg }, { status });
   }
 }

--- a/src/app/api/venue-applications/[id]/reject/route.ts
+++ b/src/app/api/venue-applications/[id]/reject/route.ts
@@ -12,6 +12,7 @@ export async function POST(_req: NextRequest, { params }: { params: Promise<{ id
     return NextResponse.json(result);
   } catch (e) {
     const msg = e instanceof Error ? e.message : "error";
-    return NextResponse.json({ error: msg }, { status: 500 });
+    const status = e instanceof Error && "status" in e ? (e as { status: number }).status : 500;
+    return NextResponse.json({ error: msg }, { status });
   }
 }


### PR DESCRIPTION
## Изменения

### #2 — XSS через `javascript:` в documentUrls
`venue-applications/[id]/page.tsx` — URL из бэкенда теперь проходит валидацию: только `http:`/`https:` рендерятся как ссылки, остальные — plain text.

### #3 — Cookie `sameSite: "strict"`
`app/api/auth/login/route.ts`: `"lax"` → `"strict"`. Кука не отправляется ни при каких cross-site запросах.

### #4 — Route Handlers пробрасывают реальный статус
Все 7 Route Handlers (approve/reject org+venue, close-sales, operations): `ApiError.status` теперь используется в ответе вместо захардкоженного `500`.

### #5 — error.tsx и not-found.tsx
Добавлены в `src/app/(admin)/`:
- `error.tsx` — Client Component с кнопкой "Попробовать снова"
- `not-found.tsx` — заглушка 404 со ссылкой на главную

## Проверка
`npm run build` — без ошибок.

Closes #2, closes #3, closes #4, closes #5