### PR TITLE
fix(#7,#8): login endpoint + refresh token поддержка

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -39,18 +39,18 @@ export default function LoginPage() {
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch(`${BASE}/auth/verify-code`, {
+      const res = await fetch(`${BASE}/auth/login`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ phone, code }),
       });
       if (!res.ok) throw new Error(await res.text());
-      const { token, userId } = await res.json();
+      const { accessToken, refreshToken, user } = await res.json();
 
       const saveRes = await fetch("/api/auth/login", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ token, userId }),
+        body: JSON.stringify({ accessToken, refreshToken, userId: user.id }),
       });
       if (!saveRes.ok) throw new Error("Не удалось сохранить сессию");
       router.push("/dashboard");

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,23 +1,24 @@
 import { NextRequest, NextResponse } from "next/server";
 
-const MAX_AGE = Number(process.env.AUTH_COOKIE_MAX_AGE ?? 86400);
+const ACCESS_TTL_SECONDS = 15 * 60; // 15 минут — соответствует backend
+const REFRESH_TTL_SECONDS = 7 * 24 * 60 * 60; // 7 дней
 const SECURE = process.env.AUTH_COOKIE_SECURE === "true";
 
 export async function POST(req: NextRequest) {
-  const { token, userId } = await req.json();
-  if (!token || !userId) {
-    return NextResponse.json({ error: "token and userId required" }, { status: 400 });
+  const { accessToken, refreshToken, userId } = await req.json();
+  if (!accessToken || !refreshToken || !userId) {
+    return NextResponse.json({ error: "accessToken, refreshToken and userId required" }, { status: 400 });
   }
 
   const res = NextResponse.json({ ok: true });
-  const cookieOpts = {
-    httpOnly: true,
-    secure: SECURE,
-    sameSite: "strict" as const,
-    maxAge: MAX_AGE,
-    path: "/",
-  };
-  res.cookies.set("auth_token", token, cookieOpts);
-  res.cookies.set("user_id", userId, cookieOpts);
+  const base = { httpOnly: true, secure: SECURE, sameSite: "strict" as const, path: "/" };
+
+  res.cookies.set("auth_token", accessToken, { ...base, maxAge: ACCESS_TTL_SECONDS });
+  res.cookies.set("refresh_token", refreshToken, { ...base, maxAge: REFRESH_TTL_SECONDS });
+  res.cookies.set("user_id", userId, { ...base, maxAge: REFRESH_TTL_SECONDS });
+  // Unix-секунды истечения access token, с запасом 30 сек для обновления в middleware
+  const expiresAt = Math.floor(Date.now() / 1000) + ACCESS_TTL_SECONDS - 30;
+  res.cookies.set("token_expires_at", String(expiresAt), { ...base, maxAge: REFRESH_TTL_SECONDS });
+
   return res;
 }

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,8 +1,28 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
-export async function POST() {
+const BASE = process.env.NEXT_PUBLIC_BACKEND_URL ?? "http://localhost:8080";
+
+export async function POST(req: NextRequest) {
+  const refreshToken = req.cookies.get("refresh_token")?.value;
+  const authToken = req.cookies.get("auth_token")?.value;
+
+  // Ревокация токенов на бэкенде (best-effort, не блокируем при ошибке)
+  if (authToken) {
+    fetch(`${BASE}/auth/logout`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${authToken}`,
+        "Content-Type": "application/json",
+      },
+      body: refreshToken ? JSON.stringify({ refreshToken }) : undefined,
+    }).catch(() => {});
+  }
+
   const res = NextResponse.json({ ok: true });
-  res.cookies.set("auth_token", "", { maxAge: 0, path: "/" });
-  res.cookies.set("user_id", "", { maxAge: 0, path: "/" });
+  const clear = { maxAge: 0, path: "/" };
+  res.cookies.set("auth_token", "", clear);
+  res.cookies.set("refresh_token", "", clear);
+  res.cookies.set("user_id", "", clear);
+  res.cookies.set("token_expires_at", "", clear);
   return res;
 }

--- a/src/app/api/auth/refresh/route.ts
+++ b/src/app/api/auth/refresh/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const BASE = process.env.NEXT_PUBLIC_BACKEND_URL ?? "http://localhost:8080";
+const ACCESS_TTL_SECONDS = 15 * 60;
+const REFRESH_TTL_SECONDS = 7 * 24 * 60 * 60;
+const SECURE = process.env.AUTH_COOKIE_SECURE === "true";
+
+export async function GET(req: NextRequest) {
+  const next = req.nextUrl.searchParams.get("next") ?? "/dashboard";
+  const refreshToken = req.cookies.get("refresh_token")?.value;
+
+  if (!refreshToken) {
+    return NextResponse.redirect(new URL("/login", req.url));
+  }
+
+  try {
+    const res = await fetch(`${BASE}/auth/refresh`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refreshToken }),
+    });
+
+    if (!res.ok) {
+      return NextResponse.redirect(new URL("/login", req.url));
+    }
+
+    const { accessToken, refreshToken: newRefreshToken } = await res.json();
+
+    const redirect = NextResponse.redirect(new URL(next, req.url));
+    const base = { httpOnly: true, secure: SECURE, sameSite: "strict" as const, path: "/" };
+
+    redirect.cookies.set("auth_token", accessToken, { ...base, maxAge: ACCESS_TTL_SECONDS });
+    redirect.cookies.set("refresh_token", newRefreshToken, { ...base, maxAge: REFRESH_TTL_SECONDS });
+    const expiresAt = Math.floor(Date.now() / 1000) + ACCESS_TTL_SECONDS - 30;
+    redirect.cookies.set("token_expires_at", String(expiresAt), { ...base, maxAge: REFRESH_TTL_SECONDS });
+
+    return redirect;
+  } catch {
+    return NextResponse.redirect(new URL("/login", req.url));
+  }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
-const PUBLIC_PATHS = ["/login", "/api/auth/login", "/api/auth/logout", "/api/health"];
+const PUBLIC_PATHS = ["/login", "/api/auth/login", "/api/auth/logout", "/api/auth/refresh", "/api/health"];
 
 export function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
@@ -8,10 +8,17 @@ export function middleware(req: NextRequest) {
 
   const token = req.cookies.get("auth_token")?.value;
   if (!token) {
-    const loginUrl = req.nextUrl.clone();
-    loginUrl.pathname = "/login";
-    return NextResponse.redirect(loginUrl);
+    return NextResponse.redirect(new URL("/login", req.url));
   }
+
+  // Если access token истекает в ближайшие 30 секунд — обновляем через refresh route
+  const expiresAt = Number(req.cookies.get("token_expires_at")?.value ?? "0");
+  if (expiresAt && Date.now() / 1000 > expiresAt) {
+    const refreshUrl = new URL("/api/auth/refresh", req.url);
+    refreshUrl.searchParams.set("next", pathname);
+    return NextResponse.redirect(refreshUrl);
+  }
+
   return NextResponse.next();
 }
 


### PR DESCRIPTION
## Проблемы

**#7:** login вызывал `POST /auth/verify-code` (не существует), должен `POST /auth/login`. Response изменился — теперь `accessToken` вместо `token`.

**#8:** Access token живёт 15 мин — без refresh через 15 мин всё ломалось.

## Изменения

- `login/page.tsx`: вызов `POST /auth/login`, извлечение `accessToken`/`refreshToken`/`user.id`
- `api/auth/login`: хранит `auth_token`, `refresh_token`, `token_expires_at` (Unix-секунды) в httpOnly cookies
- `api/auth/logout`: ревокация токенов на бэкенде (best-effort) + очистка всех cookies
- `api/auth/refresh` (новый): GET-handler, получает `next` param, обновляет токены через `POST /auth/refresh`, редиректит обратно
- `middleware`: при `token_expires_at` < now → редирект на `/api/auth/refresh?next=<path>`

Closes #7
Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)