### PR TITLE
feat(#9): имена пользователей и связанные сущности вместо UUID

### DIFF
--- a/src/app/(admin)/events/[id]/page.tsx
+++ b/src/app/(admin)/events/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { getAuthContext } from "@/lib/auth";
 import { getEvent } from "@/lib/api/events";
+import { getVenue } from "@/lib/api/venues";
 import { CloseEventSalesButton } from "./close-sales-button";
 import Link from "next/link";
 
@@ -7,6 +8,8 @@ export default async function EventPage({ params }: { params: Promise<{ id: stri
   const { id } = await params;
   const ctx = await getAuthContext();
   const event = await getEvent(ctx, id);
+
+  const venue = await getVenue(ctx, event.venueId).catch(() => null);
 
   return (
     <div className="max-w-2xl">
@@ -18,7 +21,16 @@ export default async function EventPage({ params }: { params: Promise<{ id: stri
       <h1 className="text-2xl font-semibold mb-6">{event.title}</h1>
       <div className="rounded-md border divide-y text-sm mb-6">
         <Row label="ID" value={event.id} mono />
-        <Row label="Площадка" value={event.venueId} mono />
+        <div className="flex px-4 py-3 gap-4">
+          <span className="w-32 shrink-0 text-muted-foreground">Площадка</span>
+          {venue ? (
+            <Link href={`/venues/${venue.id}`} className="hover:underline font-medium">
+              {venue.label}
+            </Link>
+          ) : (
+            <span className="font-mono text-xs text-muted-foreground">{event.venueId}</span>
+          )}
+        </div>
         <Row label="Начало" value={event.startsAt.slice(0, 16).replace("T", " ")} />
         <Row
           label="Продажи"

--- a/src/app/(admin)/organizations/[id]/page.tsx
+++ b/src/app/(admin)/organizations/[id]/page.tsx
@@ -1,12 +1,24 @@
 import { getAuthContext } from "@/lib/auth";
 import { getOrganization, listOrgMembers } from "@/lib/api/organizations";
+import { getUser } from "@/lib/api/users";
 import { StatusBadge } from "@/components/status-badge";
 import Link from "next/link";
+import { OrgMember, User } from "@/lib/api/types";
 
 export default async function OrganizationPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   const ctx = await getAuthContext();
   const [org, members] = await Promise.all([getOrganization(ctx, id), listOrgMembers(ctx, id)]);
+
+  // Загружаем имена пользователей параллельно, fallback на UUID при ошибке
+  const userMap = new Map<string, User>();
+  await Promise.all(
+    members.map((m) =>
+      getUser(ctx, m.userId)
+        .then((u) => userMap.set(m.userId, u))
+        .catch(() => {}),
+    ),
+  );
 
   return (
     <div className="max-w-2xl">
@@ -42,15 +54,34 @@ export default async function OrganizationPage({ params }: { params: Promise<{ i
               </tr>
             </thead>
             <tbody>
-              {members.map((m) => (
-                <tr key={m.id} className="border-t">
-                  <td className="px-4 py-3 font-mono text-xs">{m.userId}</td>
-                  <td className="px-4 py-3">
-                    <StatusBadge status={m.role} />
-                  </td>
-                  <td className="px-4 py-3 font-mono text-xs text-muted-foreground">{m.venueId ?? "—"}</td>
-                </tr>
-              ))}
+              {members.map((m) => {
+                const user = userMap.get(m.userId);
+                return (
+                  <tr key={m.id} className="border-t hover:bg-muted/30 transition-colors">
+                    <td className="px-4 py-3">
+                      {user ? (
+                        <Link href={`/users/${m.userId}`} className="font-medium hover:underline">
+                          {user.fullName}
+                        </Link>
+                      ) : (
+                        <span className="font-mono text-xs text-muted-foreground">{m.userId}</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3">
+                      <StatusBadge status={m.role} />
+                    </td>
+                    <td className="px-4 py-3">
+                      {m.venueId ? (
+                        <Link href={`/venues/${m.venueId}`} className="font-mono text-xs hover:underline text-muted-foreground">
+                          {m.venueId.slice(0, 8)}…
+                        </Link>
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         </div>

--- a/src/app/(admin)/venues/[id]/page.tsx
+++ b/src/app/(admin)/venues/[id]/page.tsx
@@ -1,11 +1,16 @@
 import { getAuthContext } from "@/lib/auth";
 import { getVenue } from "@/lib/api/venues";
+import { getOrganization } from "@/lib/api/organizations";
 import Link from "next/link";
 
 export default async function VenuePage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   const ctx = await getAuthContext();
   const venue = await getVenue(ctx, id);
+
+  const org = venue.organizationId
+    ? await getOrganization(ctx, venue.organizationId).catch(() => null)
+    : null;
 
   return (
     <div className="max-w-2xl">
@@ -18,7 +23,18 @@ export default async function VenuePage({ params }: { params: Promise<{ id: stri
       <div className="rounded-md border divide-y text-sm">
         <Row label="ID" value={venue.id} mono />
         <Row label="Адрес" value={venue.address ?? "—"} />
-        <Row label="Организация" value={venue.organizationId ?? "—"} mono />
+        <div className="flex px-4 py-3 gap-4">
+          <span className="w-32 shrink-0 text-muted-foreground">Организация</span>
+          {org ? (
+            <Link href={`/organizations/${org.id}`} className="hover:underline font-medium">
+              {org.name}
+            </Link>
+          ) : venue.organizationId ? (
+            <span className="font-mono text-xs text-muted-foreground">{venue.organizationId}</span>
+          ) : (
+            <span className="text-muted-foreground">—</span>
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Изменения

**organizations/[id]:**
- Участники: `userId (UUID)` → имя пользователя с ссылкой на `/users/[id]`
- `venueId` → сокращённый UUID со ссылкой на `/venues/[id]`
- Загрузка имён параллельная, fallback на UUID при ошибке

**venues/[id]:**
- `organizationId (UUID)` → название организации со ссылкой на `/organizations/[id]`

**events/[id]:**
- `venueId (UUID)` → название площадки со ссылкой на `/venues/[id]`

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)