### PR TITLE
feat(#16,#17): вход по паролю, смена пароля, создание юзеров/орг

### DIFF
--- a/src/app/(admin)/organizations/create-org-form.tsx
+++ b/src/app/(admin)/organizations/create-org-form.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+
+export function CreateOrganizationForm() {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [code, setCode] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleCreate() {
+    setError(null);
+    setLoading(true);
+    try {
+      const res = await fetch("/api/organizations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, code }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.detail ?? body.error ?? "Ошибка создания организации");
+      }
+      const org = await res.json();
+      setOpen(false);
+      setName("");
+      setCode("");
+      router.push(`/organizations/${org.id}`);
+      router.refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Ошибка");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function autoCode(value: string) {
+    setName(value);
+    if (!code) {
+      setCode(value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, ""));
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger render={<Button size="sm">+ Создать организацию</Button>} />
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Новая организация</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 pt-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="name">Название *</Label>
+            <Input
+              id="name"
+              placeholder="ООО Ромашка"
+              value={name}
+              autoFocus
+              onChange={(e) => autoCode(e.target.value)}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="code">Код (уникальный slug) *</Label>
+            <Input
+              id="code"
+              placeholder="romashka"
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleCreate()}
+            />
+          </div>
+          {error && (
+            <div className="rounded-md bg-destructive/10 border border-destructive/20 px-3 py-2">
+              <p className="text-sm text-destructive">{error}</p>
+            </div>
+          )}
+          <Button
+            className="w-full"
+            onClick={handleCreate}
+            disabled={loading || !name.trim() || !code.trim()}
+          >
+            {loading ? "Создание…" : "Создать"}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/(admin)/organizations/page.tsx
+++ b/src/app/(admin)/organizations/page.tsx
@@ -1,6 +1,7 @@
 import { getAuthContext } from "@/lib/auth";
 import { listOrganizations } from "@/lib/api/organizations";
 import Link from "next/link";
+import { CreateOrganizationForm } from "./create-org-form";
 
 export default async function OrganizationsPage() {
   const ctx = await getAuthContext();
@@ -8,7 +9,10 @@ export default async function OrganizationsPage() {
 
   return (
     <div>
-      <h1 className="text-2xl font-semibold mb-6">Организации</h1>
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-semibold">Организации</h1>
+        <CreateOrganizationForm />
+      </div>
       {orgs.length === 0 ? (
         <p className="text-muted-foreground">Организаций нет.</p>
       ) : (

--- a/src/app/(admin)/settings/change-password-form.tsx
+++ b/src/app/(admin)/settings/change-password-form.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export function ChangePasswordForm() {
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  async function handleSubmit() {
+    setError(null);
+    setSuccess(false);
+    if (newPassword !== confirmPassword) {
+      setError("Новые пароли не совпадают");
+      return;
+    }
+    if (newPassword.length < 6) {
+      setError("Новый пароль должен быть не менее 6 символов");
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await fetch("/api/admin/change-password", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ currentPassword, newPassword }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error ?? body.detail ?? "Ошибка смены пароля");
+      }
+      setSuccess(true);
+      setCurrentPassword("");
+      setNewPassword("");
+      setConfirmPassword("");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Ошибка смены пароля");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base font-semibold">Сменить пароль</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="currentPassword">Текущий пароль</Label>
+          <Input
+            id="currentPassword"
+            type="password"
+            value={currentPassword}
+            onChange={(e) => setCurrentPassword(e.target.value)}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="newPassword">Новый пароль</Label>
+          <Input
+            id="newPassword"
+            type="password"
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="confirmPassword">Повторите новый пароль</Label>
+          <Input
+            id="confirmPassword"
+            type="password"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
+          />
+        </div>
+        <Button
+          className="w-full"
+          onClick={handleSubmit}
+          disabled={loading || !currentPassword || !newPassword || !confirmPassword}
+        >
+          {loading ? "Сохранение…" : "Сменить пароль"}
+        </Button>
+        {error && (
+          <div className="rounded-md bg-destructive/10 border border-destructive/20 px-3 py-2">
+            <p className="text-sm text-destructive">{error}</p>
+          </div>
+        )}
+        {success && (
+          <div className="rounded-md bg-green-500/10 border border-green-500/20 px-3 py-2">
+            <p className="text-sm text-green-700 dark:text-green-400">Пароль успешно изменён</p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(admin)/settings/page.tsx
+++ b/src/app/(admin)/settings/page.tsx
@@ -1,0 +1,13 @@
+import { ChangePasswordForm } from "./change-password-form";
+
+export default function SettingsPage() {
+  return (
+    <div className="max-w-md space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">Настройки</h1>
+        <p className="text-muted-foreground text-sm mt-1">Управление учётной записью</p>
+      </div>
+      <ChangePasswordForm />
+    </div>
+  );
+}

--- a/src/app/(admin)/users/create-user-form.tsx
+++ b/src/app/(admin)/users/create-user-form.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+
+export function CreateUserForm() {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [fullName, setFullName] = useState("");
+  const [phone, setPhone] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleCreate() {
+    setError(null);
+    setLoading(true);
+    try {
+      const res = await fetch("/api/users", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ fullName, phone: phone || undefined }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.detail ?? body.error ?? "Ошибка создания пользователя");
+      }
+      const user = await res.json();
+      setOpen(false);
+      setFullName("");
+      setPhone("");
+      router.push(`/users/${user.id}`);
+      router.refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Ошибка");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger render={<Button size="sm">+ Создать пользователя</Button>} />
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Новый пользователь</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 pt-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="fullName">Полное имя *</Label>
+            <Input
+              id="fullName"
+              placeholder="Иван Иванов"
+              value={fullName}
+              autoFocus
+              onChange={(e) => setFullName(e.target.value)}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="phone">Телефон</Label>
+            <Input
+              id="phone"
+              type="tel"
+              placeholder="+79001234567"
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleCreate()}
+            />
+          </div>
+          {error && (
+            <div className="rounded-md bg-destructive/10 border border-destructive/20 px-3 py-2">
+              <p className="text-sm text-destructive">{error}</p>
+            </div>
+          )}
+          <Button
+            className="w-full"
+            onClick={handleCreate}
+            disabled={loading || !fullName.trim()}
+          >
+            {loading ? "Создание…" : "Создать"}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/(admin)/users/page.tsx
+++ b/src/app/(admin)/users/page.tsx
@@ -4,6 +4,7 @@ import { SearchFilter } from "@/components/search-filter";
 import { StatusBadge } from "@/components/status-badge";
 import { User } from "@/lib/api/types";
 import Link from "next/link";
+import { CreateUserForm } from "./create-user-form";
 
 export default async function UsersPage() {
   const ctx = await getAuthContext();
@@ -11,7 +12,10 @@ export default async function UsersPage() {
 
   return (
     <div>
-      <h1 className="text-2xl font-semibold mb-6">Пользователи</h1>
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-semibold">Пользователи</h1>
+        <CreateUserForm />
+      </div>
       {users.length === 0 ? (
         <p className="text-muted-foreground">Пользователей нет.</p>
       ) : (

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -12,39 +12,23 @@ const BASE = process.env.NEXT_PUBLIC_BACKEND_URL ?? "http://localhost:8080";
 export default function LoginPage() {
   const router = useRouter();
   const [phone, setPhone] = useState("");
-  const [code, setCode] = useState("");
-  const [step, setStep] = useState<"phone" | "code">("phone");
+  const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  async function sendCode() {
+  async function handleLogin() {
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch(`${BASE}/auth/send-code`, {
+      const res = await fetch(`${BASE}/admin/auth/login`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ phone }),
+        body: JSON.stringify({ phone, password }),
       });
-      if (!res.ok) throw new Error(await res.text());
-      setStep("code");
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Ошибка отправки кода");
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  async function verifyCode() {
-    setLoading(true);
-    setError(null);
-    try {
-      const res = await fetch(`${BASE}/auth/login`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ phone, code }),
-      });
-      if (!res.ok) throw new Error(await res.text());
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.detail ?? "Неверный телефон или пароль");
+      }
       const { accessToken, refreshToken, user } = await res.json();
 
       const saveRes = await fetch("/api/auth/login", {
@@ -55,7 +39,7 @@ export default function LoginPage() {
       if (!saveRes.ok) throw new Error("Не удалось сохранить сессию");
       router.push("/dashboard");
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Неверный код");
+      setError(e instanceof Error ? e.message : "Ошибка входа");
     } finally {
       setLoading(false);
     }
@@ -64,7 +48,6 @@ export default function LoginPage() {
   return (
     <div className="min-h-screen flex items-center justify-center bg-background">
       <div className="w-full max-w-sm px-4">
-        {/* Logo */}
         <div className="flex flex-col items-center mb-8">
           <div className="w-14 h-14 rounded-2xl bg-primary flex items-center justify-center shadow-md mb-3">
             <span className="text-primary-foreground text-2xl font-bold">T</span>
@@ -75,56 +58,39 @@ export default function LoginPage() {
 
         <Card className="shadow-sm">
           <CardHeader className="pb-2">
-            <CardTitle className="text-base font-semibold">
-              {step === "phone" ? "Вход в систему" : "Введите код"}
-            </CardTitle>
+            <CardTitle className="text-base font-semibold">Вход в систему</CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
-            {step === "phone" ? (
-              <>
-                <div className="space-y-1.5">
-                  <Label htmlFor="phone">Номер телефона</Label>
-                  <Input
-                    id="phone"
-                    type="tel"
-                    placeholder="+79001234567"
-                    value={phone}
-                    autoFocus
-                    onChange={(e) => setPhone(e.target.value)}
-                    onKeyDown={(e) => e.key === "Enter" && sendCode()}
-                  />
-                </div>
-                <Button className="w-full" onClick={sendCode} disabled={loading || !phone}>
-                  {loading ? "Отправка…" : "Получить код"}
-                </Button>
-              </>
-            ) : (
-              <>
-                <p className="text-sm text-muted-foreground">
-                  SMS-код отправлен на <span className="font-medium text-foreground">{phone}</span>
-                </p>
-                <div className="space-y-1.5">
-                  <Label htmlFor="code">SMS-код</Label>
-                  <Input
-                    id="code"
-                    type="text"
-                    inputMode="numeric"
-                    placeholder="123456"
-                    maxLength={6}
-                    value={code}
-                    autoFocus
-                    onChange={(e) => setCode(e.target.value.replace(/\D/g, ""))}
-                    onKeyDown={(e) => e.key === "Enter" && verifyCode()}
-                  />
-                </div>
-                <Button className="w-full" onClick={verifyCode} disabled={loading || code.length < 4}>
-                  {loading ? "Проверка…" : "Войти"}
-                </Button>
-                <Button variant="ghost" className="w-full text-muted-foreground" onClick={() => { setStep("phone"); setCode(""); setError(null); }}>
-                  Изменить номер
-                </Button>
-              </>
-            )}
+            <div className="space-y-1.5">
+              <Label htmlFor="phone">Номер телефона</Label>
+              <Input
+                id="phone"
+                type="tel"
+                placeholder="+79001234567"
+                value={phone}
+                autoFocus
+                onChange={(e) => setPhone(e.target.value)}
+                onKeyDown={(e) => e.key === "Enter" && handleLogin()}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="password">Пароль</Label>
+              <Input
+                id="password"
+                type="password"
+                placeholder="••••••••"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                onKeyDown={(e) => e.key === "Enter" && handleLogin()}
+              />
+            </div>
+            <Button
+              className="w-full"
+              onClick={handleLogin}
+              disabled={loading || !phone || !password}
+            >
+              {loading ? "Вход…" : "Войти"}
+            </Button>
             {error && (
               <div className="rounded-md bg-destructive/10 border border-destructive/20 px-3 py-2">
                 <p className="text-sm text-destructive">{error}</p>

--- a/src/app/api/admin/change-password/route.ts
+++ b/src/app/api/admin/change-password/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+const BACKEND = process.env.NEXT_PUBLIC_BACKEND_URL ?? "http://localhost:8080";
+
+export async function POST(req: NextRequest) {
+  const cookieStore = await cookies();
+  const token = cookieStore.get("auth_token")?.value;
+  if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const body = await req.json();
+  const res = await fetch(`${BACKEND}/admin/auth/change-password`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    return NextResponse.json(data, { status: res.status });
+  }
+  return new NextResponse(null, { status: 204 });
+}

--- a/src/app/api/organizations/route.ts
+++ b/src/app/api/organizations/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+const BACKEND = process.env.NEXT_PUBLIC_BACKEND_URL ?? "http://localhost:8080";
+
+export async function POST(req: NextRequest) {
+  const cookieStore = await cookies();
+  const token = cookieStore.get("auth_token")?.value;
+  const userId = cookieStore.get("user_id")?.value;
+  if (!token || !userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const body = await req.json();
+  const res = await fetch(`${BACKEND}/api/v1/organizations`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+      "X-User-Id": userId,
+    },
+    body: JSON.stringify(body),
+  });
+
+  const data = await res.json().catch(() => ({}));
+  return NextResponse.json(data, { status: res.status });
+}

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+const BACKEND = process.env.NEXT_PUBLIC_BACKEND_URL ?? "http://localhost:8080";
+
+export async function POST(req: NextRequest) {
+  const cookieStore = await cookies();
+  const token = cookieStore.get("auth_token")?.value;
+  const userId = cookieStore.get("user_id")?.value;
+  if (!token || !userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const body = await req.json();
+  const res = await fetch(`${BACKEND}/api/v1/users`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+      "X-User-Id": userId,
+    },
+    body: JSON.stringify(body),
+  });
+
+  const data = await res.json().catch(() => ({}));
+  return NextResponse.json(data, { status: res.status });
+}

--- a/src/components/admin-nav.tsx
+++ b/src/components/admin-nav.tsx
@@ -15,6 +15,7 @@ const NAV = [
   { href: "/users", label: "Пользователи", icon: "👤" },
   { href: "/operations", label: "Операции", icon: "⚙️" },
   { href: "/analytics", label: "Аналитика", icon: "📊" },
+  { href: "/settings", label: "Настройки", icon: "🔑" },
 ];
 
 export function AdminNav() {

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,160 @@
+"use client"
+
+import * as React from "react"
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { XIcon } from "lucide-react"
+
+function Dialog({ ...props }: DialogPrimitive.Root.Props) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({ ...props }: DialogPrimitive.Trigger.Props) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({ ...props }: DialogPrimitive.Portal.Props) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({ ...props }: DialogPrimitive.Close.Props) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: DialogPrimitive.Backdrop.Props) {
+  return (
+    <DialogPrimitive.Backdrop
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: DialogPrimitive.Popup.Props & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Popup
+        data-slot="dialog-content"
+        className={cn(
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            render={
+              <Button
+                variant="ghost"
+                className="absolute top-2 right-2"
+                size="icon-sm"
+              />
+            }
+          >
+            <XIcon
+            />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Popup>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close render={<Button variant="outline" />}>
+          Close
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  )
+}
+
+function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn(
+        "font-heading text-base leading-none font-medium",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: DialogPrimitive.Description.Props) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn(
+        "text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}


### PR DESCRIPTION
## Summary
- **Login page**: убран SMS OTP, вход по телефону + паролю через `POST /admin/auth/login`
- **`/settings`**: страница смены пароля с проверкой текущего пароля
- **`/users`**: кнопка «Создать пользователя» (диалог, без SMS)
- **`/organizations`**: кнопка «Создать организацию» (диалог, авто-slug из названия)
- Добавлен пункт «Настройки» в боковое меню
- Dialog компонент (@base-ui)

## Test plan
- [ ] Войти через `+79272344839` / `admin` без SMS → попасть на /dashboard
- [ ] Неверный пароль → ошибка под формой
- [ ] /settings → сменить пароль → повторный вход с новым паролем работает
- [ ] /users → создать пользователя → редирект на страницу пользователя
- [ ] /organizations → создать организацию → редирект на страницу орга

Closes #16
Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)