### PR TITLE
fix/feat: detail-страницы без 500 + смена роли пользователя

### DIFF
--- a/src/app/(admin)/organizations/[id]/page.tsx
+++ b/src/app/(admin)/organizations/[id]/page.tsx
@@ -8,7 +8,24 @@ import { OrgMember, User } from "@/lib/api/types";
 export default async function OrganizationPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   const ctx = await getAuthContext();
-  const [org, members] = await Promise.all([getOrganization(ctx, id), listOrgMembers(ctx, id)]);
+
+  let org: Organization;
+  let members: OrgMember[] = [];
+  try {
+    [org, members] = await Promise.all([getOrganization(ctx, id), listOrgMembers(ctx, id)]);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Ошибка загрузки";
+    return (
+      <div className="max-w-2xl">
+        <div className="mb-4">
+          <Link href="/organizations" className="text-sm text-muted-foreground hover:underline">
+            ← Организации
+          </Link>
+        </div>
+        <p className="text-destructive">{msg}</p>
+      </div>
+    );
+  }
 
   // Загружаем имена пользователей параллельно, fallback на UUID при ошибке
   const userMap = new Map<string, User>();

--- a/src/app/(admin)/users/[id]/change-role-button.tsx
+++ b/src/app/(admin)/users/[id]/change-role-button.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+export function ChangeRoleButton({ userId, currentRole }: { userId: string; currentRole: string }) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+
+  const targetRole = currentRole === "ADMIN" ? "USER" : "ADMIN";
+  const label = currentRole === "ADMIN" ? "Снять права админа" : "Сделать администратором";
+
+  async function handleClick() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/users/${userId}/role`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ role: targetRole }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error ?? `Ошибка ${res.status}`);
+      }
+      router.refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Ошибка");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <button
+        onClick={handleClick}
+        disabled={loading}
+        className={`text-sm px-3 py-1.5 rounded-md border transition-colors disabled:opacity-50 ${
+          targetRole === "ADMIN"
+            ? "border-amber-500 text-amber-600 hover:bg-amber-50 dark:hover:bg-amber-950"
+            : "border-muted-foreground text-muted-foreground hover:bg-muted"
+        }`}
+      >
+        {loading ? "..." : label}
+      </button>
+      {error && <p className="text-xs text-destructive">{error}</p>}
+    </div>
+  );
+}

--- a/src/app/(admin)/users/[id]/page.tsx
+++ b/src/app/(admin)/users/[id]/page.tsx
@@ -2,16 +2,33 @@ import { getAuthContext } from "@/lib/auth";
 import { getUser, listUserMemberships } from "@/lib/api/users";
 import { getOrganization } from "@/lib/api/organizations";
 import { StatusBadge } from "@/components/status-badge";
+import { ChangeRoleButton } from "./change-role-button";
 import Link from "next/link";
 
 export default async function UserPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   const ctx = await getAuthContext();
 
-  const [user, memberships] = await Promise.all([
-    getUser(ctx, id),
-    listUserMemberships(ctx, id).catch(() => []),
-  ]);
+  let user: Awaited<ReturnType<typeof getUser>>;
+  let memberships: Awaited<ReturnType<typeof listUserMemberships>> = [];
+  try {
+    [user, memberships] = await Promise.all([
+      getUser(ctx, id),
+      listUserMemberships(ctx, id).catch(() => []),
+    ]);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Ошибка загрузки";
+    return (
+      <div className="max-w-2xl">
+        <div className="mb-4">
+          <Link href="/users" className="text-sm text-muted-foreground hover:underline">
+            ← Пользователи
+          </Link>
+        </div>
+        <p className="text-destructive">{msg}</p>
+      </div>
+    );
+  }
 
   const orgsById = Object.fromEntries(
     await Promise.all(
@@ -35,9 +52,12 @@ export default async function UserPage({ params }: { params: Promise<{ id: strin
         <Row label="ID" value={user.id} mono />
         <Row label="Телефон" value={user.phone ?? "—"} />
         <Row label="Email" value={user.email ?? "—"} />
-        <div className="flex px-4 py-3 gap-4">
+        <div className="flex px-4 py-3 gap-4 items-center">
           <span className="w-32 shrink-0 text-muted-foreground">Роль</span>
-          <StatusBadge status={user.role} />
+          <div className="flex items-center gap-3">
+            <StatusBadge status={user.role} />
+            <ChangeRoleButton userId={user.id} currentRole={user.role} />
+          </div>
         </div>
       </div>
 

--- a/src/app/api/users/[id]/role/route.ts
+++ b/src/app/api/users/[id]/role/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAuthContext } from "@/lib/auth";
+import { patchUserRole } from "@/lib/api/users";
+import { revalidatePath } from "next/cache";
+
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  try {
+    const ctx = await getAuthContext();
+    const body = await req.json();
+    const result = await patchUserRole(ctx, id, body.role);
+    revalidatePath(`/users/${id}`);
+    revalidatePath("/users");
+    return NextResponse.json(result);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "error";
+    const status = e instanceof Error && "status" in e ? (e as { status: number }).status : 500;
+    return NextResponse.json({ error: msg }, { status });
+  }
+}

--- a/src/lib/api/users.ts
+++ b/src/lib/api/users.ts
@@ -12,3 +12,9 @@ export const listUserMemberships = (ctx: AuthContext, userId: string) =>
   apiFetch<OrgMember[]>(`/api/v1/organization-members?userId=${userId}`, backendHeaders(ctx), {
     cache: "no-store",
   });
+
+export const patchUserRole = (ctx: AuthContext, userId: string, role: string) =>
+  apiFetch<User>(`/api/v1/users/${userId}/role`, backendHeaders(ctx), {
+    method: "PATCH",
+    body: JSON.stringify({ role }),
+  });


### PR DESCRIPTION
## Summary
- `organizations/[id]`: try-catch вокруг `Promise.all` — 500 → сообщение об ошибке. Closes #23
- `users/[id]`: аналогично + кнопка «Сделать администратором» / «Снять права админа». Closes #24
- Новый `PATCH /api/users/[id]/role` route handler → вызывает бек
- `patchUserRole` в `lib/api/users.ts`

## Requires
Backend PR #286 (PATCH /api/v1/users/{id}/role) — уже смёрджен

## Test plan
- [ ] `/organizations/4b5e...` — страница открывается
- [ ] `/users/[id]` — кнопка смены роли видна, меняет USER→ADMIN и обратно

🤖 Generated with [Claude Code](https://claude.com/claude-code)