### PR TITLE
fix: неверный URL listOrgMembers — 401 на странице организации

### DIFF
--- a/src/lib/api/organizations.ts
+++ b/src/lib/api/organizations.ts
@@ -13,6 +13,6 @@ export const getOrganization = (ctx: AuthContext, id: string) =>
   });
 
 export const listOrgMembers = (ctx: AuthContext, orgId: string) =>
-  apiFetch<OrgMember[]>(`/api/v1/organizations/${orgId}/members`, backendHeaders(ctx), {
+  apiFetch<OrgMember[]>(`/api/v1/organization-members?organizationId=${orgId}`, backendHeaders(ctx), {
     cache: "no-store",
   });


### PR DESCRIPTION
Вызывался несуществующий /organizations/{id}/members, нужен /organization-members?organizationId=