### PR TITLE
fix(#31): отключить кнопку удаления для текущего пользователя в админке

### DIFF
--- a/src/app/(admin)/organizations/[id]/delete-member-button.tsx
+++ b/src/app/(admin)/organizations/[id]/delete-member-button.tsx
@@ -3,9 +3,17 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 
-export function DeleteMemberButton({ memberId }: { memberId: string }) {
+export function DeleteMemberButton({ memberId, isSelf }: { memberId: string; isSelf: boolean }) {
   const [loading, setLoading] = useState(false);
   const router = useRouter();
+
+  if (isSelf) {
+    return (
+      <span className="text-xs text-muted-foreground opacity-40" title="Нельзя удалить себя">
+        Удалить
+      </span>
+    );
+  }
 
   async function handleDelete() {
     if (!confirm("Удалить участника из организации?")) return;

--- a/src/app/(admin)/organizations/[id]/page.tsx
+++ b/src/app/(admin)/organizations/[id]/page.tsx
@@ -10,6 +10,7 @@ import { OrgMember, Organization, User } from "@/lib/api/types";
 export default async function OrganizationPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   const ctx = await getAuthContext();
+  const currentUserId = ctx.userId;
 
   let org: Organization;
   let members: OrgMember[] = [];
@@ -103,7 +104,7 @@ export default async function OrganizationPage({ params }: { params: Promise<{ i
                       )}
                     </td>
                     <td className="px-4 py-3 text-right">
-                      <DeleteMemberButton memberId={m.id} />
+                      <DeleteMemberButton memberId={m.id} isSelf={m.userId === currentUserId} />
                     </td>
                   </tr>
                 );


### PR DESCRIPTION
## Что изменилось
- `DeleteMemberButton`: принимает `isSelf: boolean`; при `true` — неактивный `<span>` вместо кнопки
- `OrganizationPage`: передаёт `isSelf={m.userId === currentUserId}` из auth context

Бэкенд-защита (400 при попытке): karrad1201/ticketsbackend#293

Closes #31