### PR TITLE
feat(#30): публичные страницы подачи заявок (телефон OTP → форма)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,32 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Download latest OpenAPI spec from backend
+        id: download-spec
+        continue-on-error: true
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          repo: karrad1201/ticketsbackend
+          workflow: ci-cd.yml
+          branch: main
+          name: openapi-spec
+          path: .
+
+      - name: Check API contract drift
+        if: steps.download-spec.outcome == 'success'
+        run: |
+          npm run generate-api:local
+          if ! git diff --exit-code src/lib/api/generated.ts; then
+            echo ""
+            echo "❌ OpenAPI contract drift detected!"
+            echo "   Backend API changed but generated.ts was not updated."
+            echo "   Run: npm run generate-api"
+            echo "   Then commit src/lib/api/generated.ts"
+            exit 1
+          fi
+          echo "✅ API contract is up to date"
+
       - name: Lint
         run: npm run lint
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "16.2.4",
+        "openapi-typescript": "^7.13.0",
         "tailwindcss": "^4",
         "typescript": "^5"
       }
@@ -1952,6 +1953,82 @@
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "license": "MIT"
     },
+    "node_modules/@redocly/ajv": {
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.11.2.tgz",
+      "integrity": "sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js-replace": "^1.0.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@redocly/ajv/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@redocly/config": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.22.0.tgz",
+      "integrity": "sha512-gAy93Ddo01Z3bHuVdPWfCwzgfaYgMdaZPcfL7JZ7hWJoK9V0lXDbigTWkhiPFAaLWzbOJ+kbUQG1+XwIm0KRGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@redocly/openapi-core": {
+      "version": "1.34.14",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.14.tgz",
+      "integrity": "sha512-y+xFx+Zz54Xhr8jUdnLENYnt7Y7GEDL6Q03ga7rTtX8DVwefX9H+hQEPgJp1nda7vdH+wJ9/HBVvyfBuW9x6rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/ajv": "8.11.2",
+        "@redocly/config": "0.22.0",
+        "colorette": "1.4.0",
+        "https-proxy-agent": "7.0.6",
+        "js-levenshtein": "1.1.6",
+        "js-yaml": "4.1.1",
+        "minimatch": "5.1.9",
+        "pluralize": "8.0.0",
+        "yaml-ast-parser": "0.0.43"
+      },
+      "engines": {
+        "node": ">=18.17.0",
+        "npm": ">=9.5.0"
+      }
+    },
+    "node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@redocly/openapi-core/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -3119,6 +3196,16 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
@@ -3604,6 +3691,13 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
@@ -3744,6 +3838,13 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/colorette": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
@@ -5713,6 +5814,19 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/index-to-position": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+      "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -6380,6 +6494,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/js-tokens": {
@@ -7515,6 +7639,71 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openapi-typescript": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-7.13.0.tgz",
+      "integrity": "sha512-EFP392gcqXS7ntPvbhBzbF8TyBA+baIYEm791Hy5YkjDYKTnk/Tn5OQeKm5BIZvJihpp8Zzr4hzx0Irde1LNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/openapi-core": "^1.34.6",
+        "ansi-colors": "^4.1.3",
+        "change-case": "^5.4.4",
+        "parse-json": "^8.3.0",
+        "supports-color": "^10.2.2",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "openapi-typescript": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "typescript": "^5.x"
+      }
+    },
+    "node_modules/openapi-typescript/node_modules/parse-json": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "index-to-position": "^1.1.0",
+        "type-fest": "^4.39.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openapi-typescript/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/openapi-typescript/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -7738,6 +7927,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -9465,6 +9664,13 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/uri-js-replace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uri-js-replace/-/uri-js-replace-1.0.1.tgz",
+      "integrity": "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
@@ -9715,6 +9921,13 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
+    },
+    "node_modules/yaml-ast-parser": {
+      "version": "0.0.43",
+      "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
+      "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "generate-api": "openapi-typescript https://api.visit-kalmykia.ru/v3/api-docs -o src/lib/api/generated.ts",
+    "generate-api:local": "openapi-typescript openapi.json -o src/lib/api/generated.ts"
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
@@ -30,6 +32,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.2.4",
+    "openapi-typescript": "^7.13.0",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/src/app/(public)/apply/form/org-application-form.tsx
+++ b/src/app/(public)/apply/form/org-application-form.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useState } from "react";
+
+export function OrgApplicationForm() {
+  const [name, setName] = useState("");
+  const [code, setCode] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/apply/org-application", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ organizationName: name, organizationCode: code }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.message ?? data.detail ?? "Ошибка подачи заявки");
+      setSuccess(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Ошибка");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (success) {
+    return (
+      <div className="rounded-md border border-green-200 bg-green-50 px-4 py-3">
+        <p className="text-sm text-green-800 font-medium">Заявка отправлена!</p>
+        <p className="text-sm text-green-700 mt-1">
+          Мы рассмотрим вашу заявку и свяжемся с вами.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1">
+        <label className="text-sm font-medium">Название организации</label>
+        <input
+          type="text"
+          placeholder="ООО Ромашка"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="w-full border rounded-md px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary"
+        />
+      </div>
+      <div className="space-y-1">
+        <label className="text-sm font-medium">Код организации</label>
+        <input
+          type="text"
+          placeholder="romashka"
+          value={code}
+          onChange={(e) => setCode(e.target.value)}
+          className="w-full border rounded-md px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary"
+        />
+        <p className="text-xs text-muted-foreground">Латинские буквы и цифры, без пробелов</p>
+      </div>
+      {error && <p className="text-sm text-destructive">{error}</p>}
+      <button
+        onClick={handleSubmit}
+        disabled={!name || !code || loading}
+        className="w-full bg-primary text-primary-foreground rounded-md py-2 text-sm font-medium disabled:opacity-50"
+      >
+        {loading ? "Отправка…" : "Отправить заявку"}
+      </button>
+    </div>
+  );
+}

--- a/src/app/(public)/apply/form/page.tsx
+++ b/src/app/(public)/apply/form/page.tsx
@@ -1,0 +1,62 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { OrgApplicationForm } from "./org-application-form";
+import { VenueApplicationForm } from "./venue-application-form";
+
+const BACKEND = process.env.NEXT_PUBLIC_BACKEND_URL ?? "http://localhost:8080";
+
+async function getMembership(token: string): Promise<string | null> {
+  const res = await fetch(`${BACKEND}/api/v1/my/organization/membership`, {
+    headers: { Authorization: `Bearer ${token}` },
+    cache: "no-store",
+  });
+  if (res.status === 404) return null;
+  if (!res.ok) return null;
+  const data = await res.json().catch(() => null);
+  return data?.role ?? null;
+}
+
+export default async function ApplyFormPage() {
+  const cookieStore = await cookies();
+  const token = cookieStore.get("apply_token")?.value;
+  if (!token) redirect("/apply");
+
+  const role = await getMembership(token);
+
+  if (role === "OWNER") {
+    return (
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-2xl font-semibold">Заявка на площадку</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Заполните данные площадки для рассмотрения
+          </p>
+        </div>
+        <VenueApplicationForm />
+      </div>
+    );
+  }
+
+  if (role !== null) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-2xl font-semibold">Вы уже состоите в организации</h1>
+        <p className="text-sm text-muted-foreground">
+          Ваша текущая роль: <strong>{role}</strong>. Для подачи заявки обратитесь к владельцу организации.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold">Заявка на организацию</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Заполните данные для регистрации вашей организации
+        </p>
+      </div>
+      <OrgApplicationForm />
+    </div>
+  );
+}

--- a/src/app/(public)/apply/form/venue-application-form.tsx
+++ b/src/app/(public)/apply/form/venue-application-form.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState } from "react";
+
+export function VenueApplicationForm() {
+  const [name, setName] = useState("");
+  const [city, setCity] = useState("");
+  const [subject, setSubject] = useState("");
+  const [address, setAddress] = useState("");
+  const [description, setDescription] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/apply/venue-application", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name,
+          cityLabel: city,
+          subjectLabel: subject,
+          address,
+          description: description || undefined,
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.message ?? data.detail ?? "Ошибка подачи заявки");
+      setSuccess(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Ошибка");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (success) {
+    return (
+      <div className="rounded-md border border-green-200 bg-green-50 px-4 py-3">
+        <p className="text-sm text-green-800 font-medium">Заявка отправлена!</p>
+        <p className="text-sm text-green-700 mt-1">
+          Администратор рассмотрит вашу заявку в ближайшее время.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {(
+        [
+          { label: "Название площадки", value: name, onChange: setName, placeholder: "Концертный зал «Ромашка»" },
+          { label: "Город", value: city, onChange: setCity, placeholder: "Элиста" },
+          { label: "Регион", value: subject, onChange: setSubject, placeholder: "Республика Калмыкия" },
+          { label: "Адрес", value: address, onChange: setAddress, placeholder: "ул. Ленина, 1" },
+        ] as const
+      ).map(({ label, value, onChange, placeholder }) => (
+        <div key={label} className="space-y-1">
+          <label className="text-sm font-medium">{label}</label>
+          <input
+            type="text"
+            placeholder={placeholder}
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            className="w-full border rounded-md px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary"
+          />
+        </div>
+      ))}
+      <div className="space-y-1">
+        <label className="text-sm font-medium">Описание <span className="text-muted-foreground font-normal">(необязательно)</span></label>
+        <textarea
+          placeholder="Краткое описание площадки…"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          rows={3}
+          className="w-full border rounded-md px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary resize-none"
+        />
+      </div>
+      {error && <p className="text-sm text-destructive">{error}</p>}
+      <button
+        onClick={handleSubmit}
+        disabled={!name || !city || !subject || !address || loading}
+        className="w-full bg-primary text-primary-foreground rounded-md py-2 text-sm font-medium disabled:opacity-50"
+      >
+        {loading ? "Отправка…" : "Отправить заявку"}
+      </button>
+    </div>
+  );
+}

--- a/src/app/(public)/apply/layout.tsx
+++ b/src/app/(public)/apply/layout.tsx
@@ -1,0 +1,7 @@
+export default function ApplyLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background px-4">
+      <div className="w-full max-w-md">{children}</div>
+    </div>
+  );
+}

--- a/src/app/(public)/apply/otp/page.tsx
+++ b/src/app/(public)/apply/otp/page.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Suspense } from "react";
+
+function OtpForm() {
+  const router = useRouter();
+  const params = useSearchParams();
+  const phone = params.get("phone") ?? "";
+  const [code, setCode] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleVerify() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/apply/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ phone, code }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data.message ?? data.detail ?? "Неверный код");
+      }
+      router.push("/apply/form");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Ошибка");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold">Код подтверждения</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Введите код из SMS на номер {phone}
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        <input
+          type="text"
+          inputMode="numeric"
+          placeholder="1234"
+          value={code}
+          onChange={(e) => { setCode(e.target.value); setError(null); }}
+          onKeyDown={(e) => e.key === "Enter" && handleVerify()}
+          maxLength={6}
+          className="w-full border rounded-md px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary tracking-widest text-center text-lg"
+          autoFocus
+        />
+        {error && <p className="text-sm text-destructive">{error}</p>}
+        <button
+          onClick={handleVerify}
+          disabled={!code || loading}
+          className="w-full bg-primary text-primary-foreground rounded-md py-2 text-sm font-medium disabled:opacity-50"
+        >
+          {loading ? "Проверка…" : "Войти"}
+        </button>
+        <button
+          onClick={() => router.back()}
+          className="w-full text-sm text-muted-foreground hover:underline"
+        >
+          Изменить номер
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default function OtpPage() {
+  return (
+    <Suspense>
+      <OtpForm />
+    </Suspense>
+  );
+}

--- a/src/app/(public)/apply/page.tsx
+++ b/src/app/(public)/apply/page.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { normalizePhone } from "@/lib/utils";
+
+export default function ApplyPhonePage() {
+  const router = useRouter();
+  const [phone, setPhone] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSendCode() {
+    setLoading(true);
+    setError(null);
+    try {
+      const normalized = normalizePhone(phone);
+      const res = await fetch("/api/apply/send-code", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ phone: normalized }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.message ?? "Не удалось отправить код");
+      }
+      router.push(`/apply/otp?phone=${encodeURIComponent(normalized)}`);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Ошибка");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold">Подача заявки</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Введите номер телефона для входа
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        <input
+          type="tel"
+          placeholder="+79001234567"
+          value={phone}
+          onChange={(e) => { setPhone(e.target.value); setError(null); }}
+          onKeyDown={(e) => e.key === "Enter" && handleSendCode()}
+          className="w-full border rounded-md px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary"
+          autoFocus
+        />
+        {error && <p className="text-sm text-destructive">{error}</p>}
+        <button
+          onClick={handleSendCode}
+          disabled={!phone || loading}
+          className="w-full bg-primary text-primary-foreground rounded-md py-2 text-sm font-medium disabled:opacity-50"
+        >
+          {loading ? "Отправка…" : "Получить код"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/apply/login/route.ts
+++ b/src/app/api/apply/login/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const BACKEND = process.env.NEXT_PUBLIC_BACKEND_URL ?? "http://localhost:8080";
+const ACCESS_TTL = 15 * 60;
+const SECURE = process.env.AUTH_COOKIE_SECURE === "true";
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const res = await fetch(`${BACKEND}/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    cache: "no-store",
+  });
+
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) return NextResponse.json(data, { status: res.status });
+
+  const { accessToken, user } = data;
+  const response = NextResponse.json({ userId: user.id });
+  const base = { httpOnly: true, secure: SECURE, sameSite: "strict" as const, path: "/" };
+  response.cookies.set("apply_token", accessToken, { ...base, maxAge: ACCESS_TTL });
+  response.cookies.set("apply_user_id", user.id, { ...base, maxAge: ACCESS_TTL });
+  return response;
+}

--- a/src/app/api/apply/membership/route.ts
+++ b/src/app/api/apply/membership/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const BACKEND = process.env.NEXT_PUBLIC_BACKEND_URL ?? "http://localhost:8080";
+
+export async function GET(req: NextRequest) {
+  const token = req.cookies.get("apply_token")?.value;
+  if (!token) return NextResponse.json({ role: null }, { status: 401 });
+
+  const res = await fetch(`${BACKEND}/api/v1/my/organization/membership`, {
+    headers: { Authorization: `Bearer ${token}` },
+    cache: "no-store",
+  });
+
+  if (res.status === 404) return NextResponse.json({ role: null });
+  if (!res.ok) return NextResponse.json({ role: null });
+  const data: { role: string } = await res.json().catch(() => ({ role: null }));
+  return NextResponse.json({ role: data.role });
+}

--- a/src/app/api/apply/org-application/route.ts
+++ b/src/app/api/apply/org-application/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const BACKEND = process.env.NEXT_PUBLIC_BACKEND_URL ?? "http://localhost:8080";
+
+export async function POST(req: NextRequest) {
+  const token = req.cookies.get("apply_token")?.value;
+  if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const body = await req.json();
+  const res = await fetch(`${BACKEND}/api/v1/organization-applications`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+    body: JSON.stringify(body),
+    cache: "no-store",
+  });
+
+  const data = await res.json().catch(() => ({}));
+  return NextResponse.json(data, { status: res.status });
+}

--- a/src/app/api/apply/send-code/route.ts
+++ b/src/app/api/apply/send-code/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const BACKEND = process.env.NEXT_PUBLIC_BACKEND_URL ?? "http://localhost:8080";
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const res = await fetch(`${BACKEND}/auth/send-code`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    cache: "no-store",
+  });
+  if (res.status === 204) return new NextResponse(null, { status: 204 });
+  const data = await res.json().catch(() => ({}));
+  return NextResponse.json(data, { status: res.status });
+}

--- a/src/app/api/apply/venue-application/route.ts
+++ b/src/app/api/apply/venue-application/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const BACKEND = process.env.NEXT_PUBLIC_BACKEND_URL ?? "http://localhost:8080";
+
+export async function POST(req: NextRequest) {
+  const token = req.cookies.get("apply_token")?.value;
+  if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const body = await req.json();
+  const res = await fetch(`${BACKEND}/api/v1/my/organization/venue-applications`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+    body: JSON.stringify(body),
+    cache: "no-store",
+  });
+
+  const data = await res.json().catch(() => ({}));
+  return NextResponse.json(data, { status: res.status });
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
-const PUBLIC_PATHS = ["/login", "/api/auth/login", "/api/auth/logout", "/api/auth/refresh", "/api/health", "/api/admin/login"];
+const PUBLIC_PATHS = ["/login", "/apply", "/api/auth/login", "/api/auth/logout", "/api/auth/refresh", "/api/health", "/api/admin/login", "/api/apply"];
 
 export function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;


### PR DESCRIPTION
## Флоу
1. **/apply** — ввод телефона, `POST /api/apply/send-code`
2. **/apply/otp** — ввод кода, `POST /api/apply/login` → cookie `apply_token`
3. **/apply/form** — Server Component: проверяет `GET /api/apply/membership`:
   - OWNER → `VenueApplicationForm` (название, адрес, город)
   - Обычный пользователь → `OrgApplicationForm` (название, код организации)

## Технические детали
- Отдельный cookie `apply_token` не конфликтует с admin-сессией (`auth_token`)
- Middleware: `/apply` и `/api/apply` добавлены в `PUBLIC_PATHS`

Closes #30