### PR TITLE
fix(#38): показывать ошибку при неудачном удалении участника

### DIFF
--- a/src/app/(admin)/organizations/[id]/delete-member-button.tsx
+++ b/src/app/(admin)/organizations/[id]/delete-member-button.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 
 export function DeleteMemberButton({ memberId, isSelf }: { memberId: string; isSelf: boolean }) {
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const router = useRouter();
 
   if (isSelf) {
@@ -17,22 +18,33 @@ export function DeleteMemberButton({ memberId, isSelf }: { memberId: string; isS
 
   async function handleDelete() {
     if (!confirm("Удалить участника из организации?")) return;
+    setError(null);
     setLoading(true);
     try {
-      await fetch(`/api/organization-members/${memberId}`, { method: "DELETE" });
+      const res = await fetch(`/api/organization-members/${memberId}`, { method: "DELETE" });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        setError(body.error ?? `Ошибка ${res.status}`);
+        return;
+      }
       router.refresh();
+    } catch {
+      setError("Ошибка сети");
     } finally {
       setLoading(false);
     }
   }
 
   return (
-    <button
-      onClick={handleDelete}
-      disabled={loading}
-      className="text-xs text-muted-foreground hover:text-destructive transition-colors disabled:opacity-50"
-    >
-      {loading ? "…" : "Удалить"}
-    </button>
+    <span className="inline-flex flex-col items-end gap-1">
+      {error && <span className="text-xs text-destructive">{error}</span>}
+      <button
+        onClick={handleDelete}
+        disabled={loading}
+        className="text-xs text-muted-foreground hover:text-destructive transition-colors disabled:opacity-50"
+      >
+        {loading ? "…" : "Удалить"}
+      </button>
+    </span>
   );
 }


### PR DESCRIPTION
## Summary
- Проверять `res.ok` перед `router.refresh()` в `delete-member-button.tsx`
- Показывать текст ошибки рядом с кнопкой «Удалить»
- Не обновлять список если DELETE вернул ошибку

Closes #38

## Test plan
- [ ] Нажать «Удалить» при нормальной работе → участник удаляется, список обновляется
- [ ] Симулировать ошибку сети → появляется сообщение «Ошибка сети»
- [ ] Бэкенд возвращает 403 → отображается текст ошибки, список не обновляется

🤖 Generated with [Claude Code](https://claude.com/claude-code)