### PR TITLE
fix(#40): парсить JSON вместо res.text() при ошибках

### DIFF
--- a/src/app/(admin)/categories/create-form.tsx
+++ b/src/app/(admin)/categories/create-form.tsx
@@ -24,7 +24,10 @@ export function CreateCategoryForm() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ code: code.trim(), label: label.trim() }),
       });
-      if (!res.ok) throw new Error(await res.text());
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.detail ?? body.error ?? `Ошибка ${res.status}`);
+      }
       setCode("");
       setLabel("");
       router.refresh();

--- a/src/app/(admin)/events/[id]/close-sales-button.tsx
+++ b/src/app/(admin)/events/[id]/close-sales-button.tsx
@@ -15,7 +15,10 @@ export function CloseEventSalesButton({ id }: { id: string }) {
     setError(null);
     try {
       const res = await fetch(`/api/events/${id}/close-sales`, { method: "POST" });
-      if (!res.ok) throw new Error(await res.text());
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.detail ?? body.error ?? `Ошибка ${res.status}`);
+      }
       router.refresh();
     } catch (e) {
       setError(e instanceof Error ? e.message : "Ошибка");

--- a/src/app/(admin)/org-applications/[id]/actions.tsx
+++ b/src/app/(admin)/org-applications/[id]/actions.tsx
@@ -15,7 +15,10 @@ export function OrgApplicationActions({ id }: { id: string }) {
     setError(null);
     try {
       const res = await fetch(`/api/org-applications/${id}/${action}`, { method: "POST" });
-      if (!res.ok) throw new Error(await res.text());
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.detail ?? body.error ?? `Ошибка ${res.status}`);
+      }
       router.push("/org-applications");
       router.refresh();
     } catch (e) {

--- a/src/app/(admin)/venue-applications/[id]/actions.tsx
+++ b/src/app/(admin)/venue-applications/[id]/actions.tsx
@@ -15,7 +15,10 @@ export function VenueApplicationActions({ id }: { id: string }) {
     setError(null);
     try {
       const res = await fetch(`/api/venue-applications/${id}/${action}`, { method: "POST" });
-      if (!res.ok) throw new Error(await res.text());
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.detail ?? body.error ?? `Ошибка ${res.status}`);
+      }
       router.push("/venue-applications");
       router.refresh();
     } catch (e) {


### PR DESCRIPTION
## Summary
Заменить `await res.text()` на `res.json().catch(() => ({}))` во всех client-компонентах.
При 500-ошибке Spring возвращает HTML — без этого фикса пользователь видел сырой HTML.

Затронуто:
- `categories/create-form.tsx`
- `events/[id]/close-sales-button.tsx`
- `org-applications/[id]/actions.tsx`
- `venue-applications/[id]/actions.tsx`

Closes #40

## Test plan
- [ ] Отключить бэкенд → создание категории показывает «Ошибка 502», не HTML
- [ ] Бэкенд возвращает JSON с `detail` → отображается detail
- [ ] Бэкенд возвращает JSON с `error` → отображается error

🤖 Generated with [Claude Code](https://claude.com/claude-code)