### PR TITLE
refactor(#39): вынести дублирующийся error-handling и DetailRow в утилиты

### DIFF
--- a/src/app/(admin)/events/[id]/page.tsx
+++ b/src/app/(admin)/events/[id]/page.tsx
@@ -57,7 +57,7 @@ export default async function EventPage({ params }: { params: Promise<{ id: stri
           </div>
         )}
         <DetailRow label="Начало" value={event.time.slice(0, 16).replace("T", " ")} />
-        <Row
+        <DetailRow
           label="Продажи"
           value={event.salesClosedAt ? `Закрыты ${event.salesClosedAt.slice(0, 10)}` : "Открыты"}
         />

--- a/src/app/(admin)/events/[id]/page.tsx
+++ b/src/app/(admin)/events/[id]/page.tsx
@@ -1,3 +1,4 @@
+import { DetailRow } from "@/components/detail-row";
 import { getAuthContext } from "@/lib/auth";
 import { getEvent } from "@/lib/api/events";
 import { getVenue } from "@/lib/api/venues";
@@ -26,7 +27,7 @@ export default async function EventPage({ params }: { params: Promise<{ id: stri
       </div>
       <h1 className="text-2xl font-semibold mb-6">{event.label}</h1>
       <div className="rounded-md border divide-y text-sm mb-6">
-        <Row label="ID" value={event.id} mono />
+        <DetailRow label="ID" value={event.id} mono />
         <div className="flex px-4 py-3 gap-4">
           <span className="w-40 shrink-0 text-muted-foreground">Площадка</span>
           {venue ? (
@@ -55,14 +56,14 @@ export default async function EventPage({ params }: { params: Promise<{ id: stri
             </Link>
           </div>
         )}
-        <Row label="Начало" value={event.time.slice(0, 16).replace("T", " ")} />
+        <DetailRow label="Начало" value={event.time.slice(0, 16).replace("T", " ")} />
         <Row
           label="Продажи"
           value={event.salesClosedAt ? `Закрыты ${event.salesClosedAt.slice(0, 10)}` : "Открыты"}
         />
-        {event.ageRating && <Row label="Возраст" value={event.ageRating} />}
-        {event.minPrice != null && <Row label="Цена от" value={`${event.minPrice} ₽`} />}
-        <Row label="Тип мест" value={event.hasSeatMap ? "Схема зала" : "Свободный вход"} />
+        {event.ageRating && <DetailRow label="Возраст" value={event.ageRating} />}
+        {event.minPrice != null && <DetailRow label="Цена от" value={`${event.minPrice} ₽`} />}
+        <DetailRow label="Тип мест" value={event.hasSeatMap ? "Схема зала" : "Свободный вход"} />
         {event.description && (
           <div className="flex px-4 py-3 gap-4">
             <span className="w-40 shrink-0 text-muted-foreground">Описание</span>
@@ -75,11 +76,3 @@ export default async function EventPage({ params }: { params: Promise<{ id: stri
   );
 }
 
-function Row({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
-  return (
-    <div className="flex px-4 py-3 gap-4">
-      <span className="w-40 shrink-0 text-muted-foreground">{label}</span>
-      <span className={mono ? "font-mono text-xs break-all" : ""}>{value}</span>
-    </div>
-  );
-}

--- a/src/app/(admin)/org-applications/[id]/page.tsx
+++ b/src/app/(admin)/org-applications/[id]/page.tsx
@@ -1,3 +1,4 @@
+import { DetailRow } from "@/components/detail-row";
 import { getAuthContext } from "@/lib/auth";
 import { getOrgApplication } from "@/lib/api/org-applications";
 import { StatusBadge } from "@/components/status-badge";
@@ -22,10 +23,10 @@ export default async function OrgApplicationPage({ params }: { params: Promise<{
       </div>
 
       <div className="rounded-md border divide-y text-sm mb-6">
-        <Row label="ID заявки" value={app.id} mono />
-        <Row label="Заявитель" value={app.applicantUserId} mono />
-        <Row label="Дата подачи" value={app.createdAt?.slice(0, 10) ?? "—"} />
-        <Row label="Статус" value={<StatusBadge status={app.status} />} />
+        <DetailRow label="ID заявки" value={app.id} mono />
+        <DetailRow label="Заявитель" value={app.applicantUserId} mono />
+        <DetailRow label="Дата подачи" value={app.createdAt?.slice(0, 10) ?? "—"} />
+        <DetailRow label="Статус" value={<StatusBadge status={app.status} />} />
       </div>
 
       {app.status === "PENDING" && (
@@ -35,11 +36,3 @@ export default async function OrgApplicationPage({ params }: { params: Promise<{
   );
 }
 
-function Row({ label, value, mono }: { label: string; value: React.ReactNode; mono?: boolean }) {
-  return (
-    <div className="flex px-4 py-3 gap-4">
-      <span className="w-40 shrink-0 text-muted-foreground">{label}</span>
-      <span className={mono ? "font-mono text-xs break-all" : ""}>{value}</span>
-    </div>
-  );
-}

--- a/src/app/(admin)/users/[id]/page.tsx
+++ b/src/app/(admin)/users/[id]/page.tsx
@@ -1,3 +1,4 @@
+import { DetailRow } from "@/components/detail-row";
 import { getAuthContext } from "@/lib/auth";
 import { getUser, listUserMemberships } from "@/lib/api/users";
 import { getOrganization } from "@/lib/api/organizations";
@@ -49,9 +50,9 @@ export default async function UserPage({ params }: { params: Promise<{ id: strin
       </div>
       <h1 className="text-2xl font-semibold mb-6">{user.fullName}</h1>
       <div className="rounded-md border divide-y text-sm mb-6">
-        <Row label="ID" value={user.id} mono />
-        <Row label="Телефон" value={user.phone ?? "—"} />
-        <Row label="Email" value={user.email ?? "—"} />
+        <DetailRow label="ID" value={user.id} mono />
+        <DetailRow label="Телефон" value={user.phone ?? "—"} />
+        <DetailRow label="Email" value={user.email ?? "—"} />
         <div className="flex px-4 py-3 gap-4 items-center">
           <span className="w-32 shrink-0 text-muted-foreground">Роль</span>
           <div className="flex items-center gap-3">
@@ -108,11 +109,3 @@ export default async function UserPage({ params }: { params: Promise<{ id: strin
   );
 }
 
-function Row({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
-  return (
-    <div className="flex px-4 py-3 gap-4">
-      <span className="w-32 shrink-0 text-muted-foreground">{label}</span>
-      <span className={mono ? "font-mono text-xs break-all" : ""}>{value}</span>
-    </div>
-  );
-}

--- a/src/app/(admin)/venue-applications/[id]/page.tsx
+++ b/src/app/(admin)/venue-applications/[id]/page.tsx
@@ -1,3 +1,4 @@
+import { DetailRow } from "@/components/detail-row";
 import { getAuthContext } from "@/lib/auth";
 import { getVenueApplication } from "@/lib/api/venue-applications";
 import { StatusBadge } from "@/components/status-badge";
@@ -22,15 +23,15 @@ export default async function VenueApplicationPage({ params }: { params: Promise
       </div>
 
       <div className="rounded-md border divide-y text-sm mb-6">
-        <Row label="ID" value={app.id} mono />
-        <Row label="Город" value={app.cityLabel} />
-        <Row label="Субъект РФ" value={app.subjectLabel} />
-        <Row label="Адрес" value={app.address} />
-        {app.description && <Row label="Описание" value={app.description} />}
-        <Row label="Организация" value={app.organizationId} mono />
-        <Row label="Заявитель" value={app.applicantUserId} mono />
-        <Row label="Дата подачи" value={app.createdAt?.slice(0, 10) ?? "—"} />
-        {app.venueId && <Row label="Созданная площадка" value={app.venueId} mono />}
+        <DetailRow label="ID" value={app.id} mono />
+        <DetailRow label="Город" value={app.cityLabel} />
+        <DetailRow label="Субъект РФ" value={app.subjectLabel} />
+        <DetailRow label="Адрес" value={app.address} />
+        {app.description && <DetailRow label="Описание" value={app.description} />}
+        <DetailRow label="Организация" value={app.organizationId} mono />
+        <DetailRow label="Заявитель" value={app.applicantUserId} mono />
+        <DetailRow label="Дата подачи" value={app.createdAt?.slice(0, 10) ?? "—"} />
+        {app.venueId && <DetailRow label="Созданная площадка" value={app.venueId} mono />}
       </div>
 
       {app.documentUrls.length > 0 && (
@@ -76,11 +77,3 @@ function isSafeUrl(url: string): boolean {
   }
 }
 
-function Row({ label, value, mono }: { label: string; value: React.ReactNode; mono?: boolean }) {
-  return (
-    <div className="flex px-4 py-3 gap-4">
-      <span className="w-40 shrink-0 text-muted-foreground">{label}</span>
-      <span className={mono ? "font-mono text-xs break-all" : ""}>{value}</span>
-    </div>
-  );
-}

--- a/src/app/(admin)/venues/[id]/page.tsx
+++ b/src/app/(admin)/venues/[id]/page.tsx
@@ -1,3 +1,4 @@
+import { DetailRow } from "@/components/detail-row";
 import { getAuthContext } from "@/lib/auth";
 import { getVenue } from "@/lib/api/venues";
 import { getOrganization } from "@/lib/api/organizations";
@@ -21,8 +22,8 @@ export default async function VenuePage({ params }: { params: Promise<{ id: stri
       </div>
       <h1 className="text-2xl font-semibold mb-6">{venue.label}</h1>
       <div className="rounded-md border divide-y text-sm">
-        <Row label="ID" value={venue.id} mono />
-        <Row label="Адрес" value={venue.address ?? "—"} />
+        <DetailRow label="ID" value={venue.id} mono />
+        <DetailRow label="Адрес" value={venue.address ?? "—"} />
         <div className="flex px-4 py-3 gap-4">
           <span className="w-32 shrink-0 text-muted-foreground">Организация</span>
           {org ? (
@@ -40,11 +41,3 @@ export default async function VenuePage({ params }: { params: Promise<{ id: stri
   );
 }
 
-function Row({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
-  return (
-    <div className="flex px-4 py-3 gap-4">
-      <span className="w-32 shrink-0 text-muted-foreground">{label}</span>
-      <span className={mono ? "font-mono text-xs break-all" : ""}>{value}</span>
-    </div>
-  );
-}

--- a/src/app/api/events/[id]/close-sales/route.ts
+++ b/src/app/api/events/[id]/close-sales/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getAuthContext } from "@/lib/auth";
 import { closeEventSales } from "@/lib/api/events";
 import { revalidatePath } from "next/cache";
+import { apiErrorResponse } from "@/lib/api-error";
 
 export async function POST(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
@@ -11,8 +12,6 @@ export async function POST(_req: NextRequest, { params }: { params: Promise<{ id
     revalidatePath("/events");
     return NextResponse.json(result);
   } catch (e) {
-    const msg = e instanceof Error ? e.message : "error";
-    const status = e instanceof Error && "status" in e ? (e as { status: number }).status : 500;
-    return NextResponse.json({ error: msg }, { status });
+    return apiErrorResponse(e);
   }
 }

--- a/src/app/api/operations/close-started-event-sales/route.ts
+++ b/src/app/api/operations/close-started-event-sales/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { apiErrorResponse } from "@/lib/api-error";
 import { getAuthContext } from "@/lib/auth";
 import { closeStartedEventSales } from "@/lib/api/operations";
 
@@ -8,8 +9,8 @@ export async function POST() {
     const result = await closeStartedEventSales(ctx);
     return NextResponse.json(result);
   } catch (e) {
-    const msg = e instanceof Error ? e.message : "error";
-    const status = e instanceof Error && "status" in e ? (e as { status: number }).status : 500;
-    return NextResponse.json({ error: msg }, { status });
+
+
+    return apiErrorResponse(e);
   }
 }

--- a/src/app/api/operations/process-stale-payments/route.ts
+++ b/src/app/api/operations/process-stale-payments/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { apiErrorResponse } from "@/lib/api-error";
 import { getAuthContext } from "@/lib/auth";
 import { processStalePayments } from "@/lib/api/operations";
 
@@ -8,8 +9,8 @@ export async function POST() {
     const result = await processStalePayments(ctx);
     return NextResponse.json(result);
   } catch (e) {
-    const msg = e instanceof Error ? e.message : "error";
-    const status = e instanceof Error && "status" in e ? (e as { status: number }).status : 500;
-    return NextResponse.json({ error: msg }, { status });
+
+
+    return apiErrorResponse(e);
   }
 }

--- a/src/app/api/org-applications/[id]/approve/route.ts
+++ b/src/app/api/org-applications/[id]/approve/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+import { apiErrorResponse } from "@/lib/api-error";
 import { getAuthContext } from "@/lib/auth";
 import { approveOrgApplication } from "@/lib/api/org-applications";
 import { revalidatePath } from "next/cache";
-
 export async function POST(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   try {
@@ -11,8 +11,6 @@ export async function POST(_req: NextRequest, { params }: { params: Promise<{ id
     revalidatePath("/org-applications");
     return NextResponse.json(result);
   } catch (e) {
-    const msg = e instanceof Error ? e.message : "error";
-    const status = e instanceof Error && "status" in e ? (e as { status: number }).status : 500;
-    return NextResponse.json({ error: msg }, { status });
+    return apiErrorResponse(e);
   }
 }

--- a/src/app/api/org-applications/[id]/reject/route.ts
+++ b/src/app/api/org-applications/[id]/reject/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+import { apiErrorResponse } from "@/lib/api-error";
 import { getAuthContext } from "@/lib/auth";
 import { rejectOrgApplication } from "@/lib/api/org-applications";
 import { revalidatePath } from "next/cache";
-
 export async function POST(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   try {
@@ -11,8 +11,6 @@ export async function POST(_req: NextRequest, { params }: { params: Promise<{ id
     revalidatePath("/org-applications");
     return NextResponse.json(result);
   } catch (e) {
-    const msg = e instanceof Error ? e.message : "error";
-    const status = e instanceof Error && "status" in e ? (e as { status: number }).status : 500;
-    return NextResponse.json({ error: msg }, { status });
+    return apiErrorResponse(e);
   }
 }

--- a/src/app/api/users/[id]/role/route.ts
+++ b/src/app/api/users/[id]/role/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+import { apiErrorResponse } from "@/lib/api-error";
 import { getAuthContext } from "@/lib/auth";
 import { patchUserRole } from "@/lib/api/users";
 import { revalidatePath } from "next/cache";
-
 export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   try {
@@ -13,8 +13,6 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     revalidatePath("/users");
     return NextResponse.json(result);
   } catch (e) {
-    const msg = e instanceof Error ? e.message : "error";
-    const status = e instanceof Error && "status" in e ? (e as { status: number }).status : 500;
-    return NextResponse.json({ error: msg }, { status });
+    return apiErrorResponse(e);
   }
 }

--- a/src/app/api/venue-applications/[id]/approve/route.ts
+++ b/src/app/api/venue-applications/[id]/approve/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+import { apiErrorResponse } from "@/lib/api-error";
 import { getAuthContext } from "@/lib/auth";
 import { approveVenueApplication } from "@/lib/api/venue-applications";
 import { revalidatePath } from "next/cache";
-
 export async function POST(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   try {
@@ -11,8 +11,6 @@ export async function POST(_req: NextRequest, { params }: { params: Promise<{ id
     revalidatePath("/venue-applications");
     return NextResponse.json(result);
   } catch (e) {
-    const msg = e instanceof Error ? e.message : "error";
-    const status = e instanceof Error && "status" in e ? (e as { status: number }).status : 500;
-    return NextResponse.json({ error: msg }, { status });
+    return apiErrorResponse(e);
   }
 }

--- a/src/app/api/venue-applications/[id]/reject/route.ts
+++ b/src/app/api/venue-applications/[id]/reject/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+import { apiErrorResponse } from "@/lib/api-error";
 import { getAuthContext } from "@/lib/auth";
 import { rejectVenueApplication } from "@/lib/api/venue-applications";
 import { revalidatePath } from "next/cache";
-
 export async function POST(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   try {
@@ -11,8 +11,6 @@ export async function POST(_req: NextRequest, { params }: { params: Promise<{ id
     revalidatePath("/venue-applications");
     return NextResponse.json(result);
   } catch (e) {
-    const msg = e instanceof Error ? e.message : "error";
-    const status = e instanceof Error && "status" in e ? (e as { status: number }).status : 500;
-    return NextResponse.json({ error: msg }, { status });
+    return apiErrorResponse(e);
   }
 }

--- a/src/components/detail-row.tsx
+++ b/src/components/detail-row.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+export function DetailRow({
+  label,
+  value,
+  mono,
+}: {
+  label: string;
+  value: React.ReactNode;
+  mono?: boolean;
+}) {
+  return (
+    <div className="flex px-4 py-3 gap-4">
+      <span className="w-32 shrink-0 text-muted-foreground">{label}</span>
+      <span className={mono ? "font-mono text-xs break-all" : ""}>{value}</span>
+    </div>
+  );
+}

--- a/src/lib/api-error.ts
+++ b/src/lib/api-error.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+
+/** Извлекает HTTP-статус из ошибки если она содержит поле status */
+function errorStatus(e: unknown): number {
+  if (e instanceof Error && "status" in e && typeof (e as { status: unknown }).status === "number") {
+    return (e as { status: number }).status;
+  }
+  return 500;
+}
+
+/** Универсальный обработчик ошибок для API routes */
+export function apiErrorResponse(e: unknown): NextResponse {
+  const msg = e instanceof Error ? e.message : "Внутренняя ошибка сервера";
+  return NextResponse.json({ error: msg }, { status: errorStatus(e) });
+}


### PR DESCRIPTION
## Summary
### lib/api-error.ts
Новая утилита `apiErrorResponse(e)` — убирает 3-строчный дублирующийся блок из 8 API routes:
```ts
// было в каждом route:
const msg = e instanceof Error ? e.message : "error";
const status = e instanceof Error && "status" in e ? (e as { status: number }).status : 500;
return NextResponse.json({ error: msg }, { status });

// стало:
return apiErrorResponse(e);
```

### components/detail-row.tsx
Новый компонент `DetailRow` — убирает локальный `function Row` из 5 detail-страниц (users, events, venues, org-applications, venue-applications).

Closes #39

## Test plan
- [ ] Сборка проекта без TypeScript ошибок
- [ ] Страницы users/[id], events/[id], venues/[id] отображают данные корректно
- [ ] API routes возвращают правильный статус при ошибках бэкенда

🤖 Generated with [Claude Code](https://claude.com/claude-code)