### PR TITLE
fix(#36,#37): refresh token через POST + RBAC проверка роли в middleware

### DIFF
--- a/src/app/api/auth/refresh/route.ts
+++ b/src/app/api/auth/refresh/route.ts
@@ -5,12 +5,11 @@ const ACCESS_TTL_SECONDS = 15 * 60;
 const REFRESH_TTL_SECONDS = 7 * 24 * 60 * 60;
 const SECURE = process.env.AUTH_COOKIE_SECURE === "true";
 
-export async function GET(req: NextRequest) {
-  const next = req.nextUrl.searchParams.get("next") ?? "/dashboard";
+export async function POST(req: NextRequest) {
   const refreshToken = req.cookies.get("refresh_token")?.value;
 
   if (!refreshToken) {
-    return NextResponse.redirect(new URL("/login", req.url));
+    return NextResponse.json({ error: "no_refresh_token" }, { status: 401 });
   }
 
   try {
@@ -21,21 +20,21 @@ export async function GET(req: NextRequest) {
     });
 
     if (!res.ok) {
-      return NextResponse.redirect(new URL("/login", req.url));
+      return NextResponse.json({ error: "refresh_failed" }, { status: 401 });
     }
 
     const { accessToken, refreshToken: newRefreshToken } = await res.json();
 
-    const redirect = NextResponse.redirect(new URL(next, req.url));
+    const response = NextResponse.json({ ok: true });
     const base = { httpOnly: true, secure: SECURE, sameSite: "strict" as const, path: "/" };
 
-    redirect.cookies.set("auth_token", accessToken, { ...base, maxAge: ACCESS_TTL_SECONDS });
-    redirect.cookies.set("refresh_token", newRefreshToken, { ...base, maxAge: REFRESH_TTL_SECONDS });
+    response.cookies.set("auth_token", accessToken, { ...base, maxAge: ACCESS_TTL_SECONDS });
+    response.cookies.set("refresh_token", newRefreshToken, { ...base, maxAge: REFRESH_TTL_SECONDS });
     const expiresAt = Math.floor(Date.now() / 1000) + ACCESS_TTL_SECONDS - 30;
-    redirect.cookies.set("token_expires_at", String(expiresAt), { ...base, maxAge: REFRESH_TTL_SECONDS });
+    response.cookies.set("token_expires_at", String(expiresAt), { ...base, maxAge: REFRESH_TTL_SECONDS });
 
-    return redirect;
+    return response;
   } catch {
-    return NextResponse.redirect(new URL("/login", req.url));
+    return NextResponse.json({ error: "internal_error" }, { status: 500 });
   }
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,7 +2,21 @@ import { NextRequest, NextResponse } from "next/server";
 
 const PUBLIC_PATHS = ["/login", "/apply", "/api/auth/login", "/api/auth/logout", "/api/auth/refresh", "/api/health", "/api/admin/login", "/api/apply"];
 
-export function middleware(req: NextRequest) {
+const BASE = process.env.NEXT_PUBLIC_BACKEND_URL ?? "http://localhost:8080";
+const ACCESS_TTL_SECONDS = 15 * 60;
+const REFRESH_TTL_SECONDS = 7 * 24 * 60 * 60;
+const SECURE = process.env.AUTH_COOKIE_SECURE === "true";
+
+function getJwtRole(token: string): string | null {
+  try {
+    const payload = JSON.parse(atob(token.split(".")[1]));
+    return payload.role ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
   if (PUBLIC_PATHS.some((p) => pathname.startsWith(p))) return NextResponse.next();
 
@@ -11,12 +25,37 @@ export function middleware(req: NextRequest) {
     return NextResponse.redirect(new URL("/login", req.url));
   }
 
-  // Если access token истекает в ближайшие 30 секунд — обновляем через refresh route
+  // Если access token истёк — обновляем inline через бекенд (без GET-редиректа)
   const expiresAt = Number(req.cookies.get("token_expires_at")?.value ?? "0");
   if (expiresAt && Date.now() / 1000 > expiresAt) {
-    const refreshUrl = new URL("/api/auth/refresh", req.url);
-    refreshUrl.searchParams.set("next", pathname);
-    return NextResponse.redirect(refreshUrl);
+    const refreshToken = req.cookies.get("refresh_token")?.value;
+    if (!refreshToken) return NextResponse.redirect(new URL("/login", req.url));
+
+    try {
+      const res = await fetch(`${BASE}/auth/refresh`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ refreshToken }),
+      });
+      if (!res.ok) return NextResponse.redirect(new URL("/login", req.url));
+
+      const { accessToken, refreshToken: newRefreshToken } = await res.json();
+      const response = NextResponse.next();
+      const base = { httpOnly: true, secure: SECURE, sameSite: "strict" as const, path: "/" };
+      response.cookies.set("auth_token", accessToken, { ...base, maxAge: ACCESS_TTL_SECONDS });
+      response.cookies.set("refresh_token", newRefreshToken, { ...base, maxAge: REFRESH_TTL_SECONDS });
+      const newExpiry = Math.floor(Date.now() / 1000) + ACCESS_TTL_SECONDS - 30;
+      response.cookies.set("token_expires_at", String(newExpiry), { ...base, maxAge: REFRESH_TTL_SECONDS });
+      return response;
+    } catch {
+      return NextResponse.redirect(new URL("/login", req.url));
+    }
+  }
+
+  // RBAC: только пользователи с ролью ADMIN допускаются в защищённые маршруты
+  const role = getJwtRole(token);
+  if (role !== "ADMIN") {
+    return NextResponse.redirect(new URL("/login", req.url));
   }
 
   return NextResponse.next();


### PR DESCRIPTION
## Summary

- **#36**: `GET /api/auth/refresh` → `POST`. Middleware больше не делает redirect на refresh-URL — refresh выполняется inline через fetch на бекенд, новые куки ставятся в том же ответе.
- **#37**: Middleware декодирует JWT payload и проверяет `role === 'ADMIN'`. Пользователи без этой роли редиректятся на `/login`.

## Changes

- `src/app/api/auth/refresh/route.ts`: GET → POST, возвращает JSON `{ok: true}` вместо redirect
- `src/middleware.ts`: async inline refresh + `getJwtRole()` helper для RBAC

## Test plan

- [ ] Войти под ADMIN → доступ открыт
- [ ] Войти под обычным пользователем → редирект на `/login`
- [ ] Дождаться истечения токена → автообновление без перехода на `/api/auth/refresh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)